### PR TITLE
Update Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "easyip": "./cli.js"
   },
   "scripts": {
-    "check": "npm install && npm outdated",
-    "update": "ncu -u && npm update && npm install",
     "test": "mocha ./Test/index.js --timeout 10000"
   },
   "repository": {
@@ -29,7 +27,6 @@
   "homepage": "https://github.com/PaulRosset/EasyIP#readme",
   "devDependencies": {
     "expect.js": "0.3.1",
-    "npm-check-updates": "^12.1.0",
     "mocha": "9.1.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "easyip": "./cli.js"
   },
   "scripts": {
+    "check": "npm install && npm outdated",
+    "update": "ncu -u && npm update && npm install",
     "test": "mocha ./Test/index.js --timeout 10000"
   },
   "repository": {
@@ -27,13 +29,14 @@
   "homepage": "https://github.com/PaulRosset/EasyIP#readme",
   "devDependencies": {
     "expect.js": "0.3.1",
-    "mocha": "3.3.0"
+    "npm-check-updates": "^12.1.0",
+    "mocha": "9.1.3"
   },
   "dependencies": {
-    "chalk": "1.1.3",
-    "commander": "2.9.0",
-    "lodash": "4.17.4",
-    "moment": "2.18.1",
-    "superagent": "3.5.2"
+    "chalk": "5.0.0",
+    "commander": "8.3.0",
+    "lodash": "4.17.21",
+    "moment": "2.29.1",
+    "superagent": "7.0.2"
   }
 }


### PR DESCRIPTION
 Dependabot cannot update superagent to a non-vulnerable version
The latest possible version that can be installed is 3.5.2 because of the following conflicting dependency:

easy-ip@1.0.0 requires superagent@3.5.2
The earliest fixed version is 7.0.2.
View logs or learn more about troubleshooting Dependabot errors.
1 superagent vulnerability found in package-lock.json 6 days ago
Remediation

Upgrade superagent to version 3.7.0 or later. For example:

"dependencies": {
  "superagent": ">=3.7.0"
}
or…
"devDependencies": {
  "superagent": ">=3.7.0"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details

CVE-2017-16129

low severity
Vulnerable versions: < 3.7.0
Patched version: 3.7.0
Affected versions of superagent do not check the post-decompression size of ZIP compressed HTTP responses prior to decompressing. This results in the package being vulnerable to a ZIP bomb attack, where an extremely small ZIP file becomes many orders of magnitude larger when decompressed.

This may result in unrestrained CPU/Memory/Disk consumption, causing a denial of service condition.

Recommendation

Update to version 3.7.0 or later.